### PR TITLE
Update Dockerfile, cmake added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN \
 
 RUN \
   # Additional system dependencies
-  apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y procps libsasl2-dev libssh-dev libgit2-dev libmariadb-dev libmariadb-dev-compat libpq-dev libsodium-dev libgit2-dev libssh2-1-dev openssh-client && \
+  apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y procps libsasl2-dev libssh-dev libgit2-dev libmariadb-dev libmariadb-dev-compat libpq-dev libsodium-dev libgit2-dev libssh2-1-dev openssh-client cmake && \
   # Update R packages
   #RUN Rscript -e "update.packages(ask = FALSE, repos = c('https://cloud.r-project.org'), instlib = '/usr/local/lib/R/site-library')"  && \
   # Install required R packages


### PR DESCRIPTION
DataSHIELD base library `dsBase` fails to install on `docker-rock` container. It seems like the reason is the `nloptr` dependency which depends on `NLOpt`. `NLOpt` is apparently compiled from source using `cmake`, when `cmake` is not installed installation of `dsBase` fails. To solve this problem, I logged into the bash of the container and installed `cmake` and it was solved.

Thus, as a quick fix, I suggested to add `cmake` as an additional system dependency. 

Here is the error output from the `RServer` log:
```
Installing package into /var/lib/rock/R/library
(as lib is unspecified)
also installing the dependencies nloptr, lme4

trying URL 'https://cloud.r-project.org/src/contrib/nloptr_2.0.0.tar.gz'
Content type 'application/x-gzip' length 2219414 bytes (2.1 MB)
==================================================
downloaded 2.1 MB

trying URL 'https://cloud.r-project.org/src/contrib/lme4_1.1-28.tar.gz'
Content type 'application/x-gzip' length 3306775 bytes (3.2 MB)
==================================================
downloaded 3.2 MB

trying URL 'https://cran.obiba.org/src/contrib/dsBase_6.1.1.tar.gz'
Content type 'application/gzip' length 380102 bytes (371 KB)
==================================================
downloaded 371 KB

* installing *source* package nloptr ...
** package nloptr successfully unpacked and MD5 sums checked
** using staged installation
checking whether the C++ compiler works... yes
checking for C++ compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C++ compiler... yes
checking whether g++ -std=gnu++14 accepts -g... yes
checking how to run the C++ preprocessor... g++ -std=gnu++14 -E
checking whether we are using the GNU C++ compiler... (cached) yes
checking whether g++ -std=gnu++14 accepts -g... (cached) yes
checking for pkg-config... /usr/bin/pkg-config
checking if pkg-config knows NLopt... no
using NLopt via local cmake build on x86_64 

------------------ CMAKE NOT FOUND --------------------

CMake was not found on the PATH. Please install CMake:

 - yum install cmake          (Fedora/CentOS; inside a terminal)
 - apt install cmake          (Debian/Ubuntu; inside a terminal).
 - pacman -S cmake            (Arch Linux; inside a terminal).
 - brew install cmake         (MacOS; inside a terminal with Homebrew)
 - port install cmake         (MacOS; inside a terminal with MacPorts)

Alternatively install CMake from: <https://cmake.org/>

-------------------------------------------------------

configure: creating ./config.status
config.status: creating src/Makevars
** libs
gcc -std=gnu99 -I"/usr/share/R/include" -DNDEBUG -I../inst/include  -I'/usr/local/lib/R/site-library/testthat/include'    -fpic  -g -O2 -ffile-prefix-map=/home/jranke/git/r-backports/bullseye/r-base-4.1.1=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c init_nloptr.c -o init_nloptr.o
gcc -std=gnu99 -I"/usr/share/R/include" -DNDEBUG -I../inst/include  -I'/usr/local/lib/R/site-library/testthat/include'    -fpic  -g -O2 -ffile-prefix-map=/home/jranke/git/r-backports/bullseye/r-base-4.1.1=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c nloptr.c -o nloptr.o
g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG -I../inst/include  -I'/usr/local/lib/R/site-library/testthat/include'    -fpic  -g -O2 -ffile-prefix-map=/home/jranke/git/r-backports/bullseye/r-base-4.1.1=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c test-C-API.cpp -o test-C-API.o
g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG -I../inst/include  -I'/usr/local/lib/R/site-library/testthat/include'    -fpic  -g -O2 -ffile-prefix-map=/home/jranke/git/r-backports/bullseye/r-base-4.1.1=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c test-runner.cpp -o test-runner.o
g++ -std=gnu++11 -shared -L/usr/lib/R/lib -Wl,-z,relro -o nloptr.so init_nloptr.o nloptr.o test-C-API.o test-runner.o -llapack -lblas -lgfortran -lm -lquadmath -Lnlopt/lib -lnlopt -L/usr/lib/R/lib -lR
/usr/bin/ld: cannot find -lnlopt
collect2: error: ld returned 1 exit status
make: *** [/usr/share/R/share/make/shlib.mk:10: nloptr.so] Error 1
ERROR: compilation failed for package nloptr
* removing /var/lib/rock/R/library/nloptr
ERROR: dependency nloptr is not available for package lme4
* removing /var/lib/rock/R/library/lme4
ERROR: dependency lme4 is not available for package dsBase
* removing /var/lib/rock/R/library/dsBase
```
